### PR TITLE
Create servedoc in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ doc:
 docupdate:
 	cd docs && make html && cd ..
 
+servedoc:
+	$(PYTHON) -m http.server --directory docs/build/html/
+
 lint:
 	flake8 docs/ examples/ pylops/ pytests/ tutorials/
 


### PR DESCRIPTION
This PR makes it easy for developers to view docs locally by adding `make servedoc` as an option in the `Makefile`.